### PR TITLE
fixing logging issue with user which has no existing cart

### DIFF
--- a/src/Security/Authentication/Provider/AuthenticationProvider.php
+++ b/src/Security/Authentication/Provider/AuthenticationProvider.php
@@ -90,8 +90,14 @@ class AuthenticationProvider extends UserAuthenticationProvider
             }
             $user->setId($customer->getId());
             $this->session->set(CustomerRepository::CUSTOMER_ID, $customer->getId());
-            $this->session->set(CartRepository::CART_ID, $result->getCart()->getId());
-            $this->session->set(CartRepository::CART_ITEM_COUNT, $result->getCart()->getLineItemCount());
+            $this->session->set(
+                CartRepository::CART_ID,
+                $result->getCart() === null ? null : $result->getCart()->getId()
+            );
+            $this->session->set(
+                CartRepository::CART_ITEM_COUNT,
+                $result->getCart() === null ? null : $result->getCart()->getLineItemCount()
+            );
         }
     }
 


### PR DESCRIPTION
given scenario:
create a user via commercetools backend
use the authentication method in this library. 

Logging caused the following error: 

![image](https://cloud.githubusercontent.com/assets/4624237/16480144/c72fb3d0-3ea4-11e6-9049-5e1890d59d5c.png)

with this pr we check if the user has an valid cart.